### PR TITLE
Use regular sbt in CI release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: olafurpg/setup-gpg@v2
       - name: Publish
         run: |
-          csbt clean ci-release
+          sbt clean ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Releasing with csbt doesn't seem to work with sbt 1.4.