### PR TITLE
Fix `README.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ package-lock.json
 .metals/
 .bloop/
 metals.sbt
+.idea
 
 # hydra
 .hydra/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Quick Start
 
-To use discipline-munit in an existing SBT project with Scala 2.11 or a later version, add the following dependencies to your
+To use discipline-munit in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "discipline-munit" % "<version>"
+  "org.typelevel" %%% "discipline-munit" % "<version>" % Test
 )
 ```


### PR DESCRIPTION
`discipline-munit` is no longer published for Scala 2.11 since `1.0.6` 